### PR TITLE
Update ajax_page_list.php

### DIFF
--- a/blocks/page_list/templates/ajax_page_list.php
+++ b/blocks/page_list/templates/ajax_page_list.php
@@ -77,7 +77,7 @@ $(document).ready(function() {
 
     $('#ajax-paginator a, .page-list-filter a').live('click', function(ev) {
 	ev.preventDefault();
-	var link_href = $(this).attr('data-href');
+	var link_href = $(this).attr('data-href').replace(/\s/g,"%20");
 
 	$('#ajax-article-list').fadeTo('fast', 0, function() {
 	    $('.page-list-filters').css({'background': 'url(<?php echo DIR_REL ?>/packages/ajax_page_list/loading.gif) 0 bottom no-repeat'});


### PR DESCRIPTION
Added '.replace(/\s/g,"%20");' to 'var link_href'

This allows for use of select attribute values with multiple word/spaces - Fixes small issue with list not updating correctly with select option values using multiple words.
